### PR TITLE
Add flag to specify instance type to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 kubeconfig*
 ec2-k3s*
+Pulumi.y*ml*

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,3 @@ clean: ## Delete compiled binary from root directory
 .PHONY: connect
 connect: ## Connect to ec2 instance via SSH
 	hack/connect.sh
-
-.PHONY: up
-up: ## Provision infrastructure
-	hack/infra-up.sh
-
-.PHONY: down
-down: ## Teardown infrastructure
-	hack/infra-down.sh

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
 
 - Create [k3s](https://docs.k3s.io/) cluster on the ec2 instance
 
-## Dependencies
-
-The following dependencies are required to run this:
+## Prerequisites
 
 - [go](https://go.dev/doc/install) `1.19`
 
@@ -29,8 +27,6 @@ The following dependencies are required to run this:
 ## Technical Specs
 
 - `Ubuntu 22.04 LTS` AMI for the ec2 instance
-
-- `t3.2xlarge` ec2 instance type
 
 - Security group
 
@@ -60,18 +56,32 @@ make help
 
 Build from source
 
+The build step outputs the binary in the current working directory
+
 ```bash
 make build
 ```
 
-Create AWS infrastructure and k3s cluster
+It can be executed by referencing it as `./ec2-k3s`
+
+Provision a k3s cluster in AWS
 
 ```bash
-make up
+./ec2-k3s up
 ```
 
-Tear down AWS infrastructure
+By default, `ec2-k3s up` will use an ec2 instance type of `t2.micro`
+
+To view a full list of options, see [here](https://aws.amazon.com/ec2/instance-types/)
+
+To specify the ec2 instance type to use:
 
 ```bash
-make down
+./ec2-k3s up --instance-type t2.small
+```
+
+Teardown AWS infrastructure and k3s cluster
+
+```bash
+./ec2-k3s down
 ```

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
 rm -rf ./ec2-k3s
+
+if [ -f "./kubeconfig" ]; then
+    rm ./kubeconfig
+fi

--- a/hack/infra-down.sh
+++ b/hack/infra-down.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-rm ./kubeconfig
-./ec2-k3s down

--- a/hack/infra-up.sh
+++ b/hack/infra-up.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-./ec2-k3s up

--- a/src/cmd/down.go
+++ b/src/cmd/down.go
@@ -11,9 +11,10 @@ import (
 // downCmd represents the down command
 var downCmd = &cobra.Command{
 	Use:   "down",
+	Args:  cobra.MaximumNArgs(0),
 	Short: "Teardown AWS infrastructure and k3s cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		infra.Down()
+		infra.Down(o.InstanceType)
 	},
 }
 

--- a/src/cmd/up.go
+++ b/src/cmd/up.go
@@ -5,18 +5,26 @@ package cmd
 
 import (
 	"github.com/lucasrod16/ec2-k3s/src/internal/infra"
+	"github.com/lucasrod16/ec2-k3s/src/internal/types"
 	"github.com/spf13/cobra"
 )
 
+var o = &types.InstanceOptions{}
+
 // upCmd represents the up command
-var upCmd = &cobra.Command{
-	Use:   "up",
-	Short: "Provision AWS infrastructure and k3s cluster",
-	Run: func(cmd *cobra.Command, args []string) {
-		infra.Up()
-	},
-}
+var (
+	upCmd = &cobra.Command{
+		Use:   "up",
+		Args:  cobra.MaximumNArgs(0),
+		Short: "Provision AWS infrastructure and k3s cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			infra.Up(o.InstanceType)
+		},
+	}
+)
 
 func init() {
+	upCmd.Flags().StringVar(&o.InstanceType, "instance-type", "t2.micro", "ec2 instance type to use")
+
 	rootCmd.AddCommand(upCmd)
 }

--- a/src/internal/infra/ec2.go
+++ b/src/internal/infra/ec2.go
@@ -69,7 +69,7 @@ func CreateSSHKeyPair(ctx *pulumi.Context) (*types.Infrastructure, error) {
 }
 
 // CreateInstance creates an ec2 instance in AWS
-func CreateInstance(ctx *pulumi.Context) (*types.Infrastructure, error) {
+func CreateInstance(ctx *pulumi.Context, instanceType string) (*types.Infrastructure, error) {
 	computeInfra, err := getUbuntuAMI(ctx)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func CreateInstance(ctx *pulumi.Context) (*types.Infrastructure, error) {
 
 	server, err := pec2.NewInstance(ctx, "ec2-instance", &pec2.InstanceArgs{
 		Ami:                 pulumi.String(computeInfra.Ami.ImageId),
-		InstanceType:        pulumi.String("t3.2xlarge"),
+		InstanceType:        pulumi.String(instanceType),
 		KeyName:             pulumi.String("ec2-k3s-keypair"),
 		VpcSecurityGroupIds: pulumi.StringArray{securityInfra.SecurityGroup.ID()},
 		Tags: pulumi.StringMap{

--- a/src/internal/infra/k3s.go
+++ b/src/internal/infra/k3s.go
@@ -1,7 +1,10 @@
 package infra
 
 import (
+	"os"
+
 	execute "github.com/alexellis/go-execute/pkg/v1"
+	"github.com/pterm/pterm"
 )
 
 /*
@@ -26,33 +29,54 @@ func K3sUp() error {
 			"--user=" + userName,
 			"--k3s-extra-args=" + disableTraefik,
 		},
-		StreamStdio: true,
+		StreamStdio: false,
 	}
 
+	s.Start()
+	pterm.Info.Println("Creating k3s cluster on ec2 instance...")
 	_, err = task.Execute()
 	if err != nil {
 		return err
 	}
+	s.Stop()
+
+	pterm.Success.Println("Successfully created k3s cluster on ec2 instance!")
 
 	return nil
 }
 
 // K3sReady waits for k3s cluster node to be ready
 func K3sReady() error {
-	kubeconfig := "./kubeconfig"
+	kubeconfig := "kubeconfig"
 	task := execute.ExecTask{
 		Command: "k3sup",
 		Args: []string{
 			"ready",
 			"--kubeconfig=" + kubeconfig,
 		},
-		StreamStdio: true,
+		StreamStdio: false,
 	}
 
+	s.Start()
+	pterm.Info.Println("Waiting for k3s cluster node to be ready...")
 	_, err := task.Execute()
 	if err != nil {
 		return err
 	}
+	s.Stop()
+
+	pterm.Success.Println("Node is ready!")
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	kubeconfigPath := workingDir + "/" + kubeconfig
+
+	pterm.Info.Printf(`Access your cluster:
+	export KUBECONFIG=%v
+	kubectl get node -o wide`, kubeconfigPath)
 
 	return nil
 }

--- a/src/internal/types/types.go
+++ b/src/internal/types/types.go
@@ -10,3 +10,7 @@ type Infrastructure struct {
 	SecurityGroup *ec2.SecurityGroup
 	Server        *ec2.Instance
 }
+
+type InstanceOptions struct {
+	InstanceType string
+}


### PR DESCRIPTION
- Add `--instance-type` flag to specify instance type to use
- Remove `infra-down` and `infra-up` scripts
- Remove `down` and `up` targets from Makefile
- Hush `k3sup` output

